### PR TITLE
Guarded against an unlikely edge case 

### DIFF
--- a/src/FubuValidation.Tests/Fields/FieldValidationQueryTester.cs
+++ b/src/FubuValidation.Tests/Fields/FieldValidationQueryTester.cs
@@ -44,10 +44,26 @@ namespace FubuValidation.Tests.Fields
         }
 
         [Test]
-        public void should_respect_continue_validation_rules_for_ancillary_objects()
+        public void should_continue_and_find_rules_for_nested__continued_ancillary_objects()
+        {
+            _query
+                .RulesFor<UserModel>(m => m.Site.Contact.FirstName)
+                .ShouldHaveCount(1);
+        }
+
+        [Test]
+        public void should_not_get_rules_for_ancillary_objects_without_a_continue_validation()
         {
             _query
                 .RulesFor<CompositeModel>(m => m.RestrictedContact.FirstName)
+                .ShouldHaveCount(0);
+        }
+
+        [Test]
+        public void should_not_get_rules_for_nested_ancillary_objects_without_a_continue_validation()
+        {
+            _query
+                .RulesFor<UserModel>(m => m.Site.AlternateContact.FirstName)
                 .ShouldHaveCount(0);
         }
 

--- a/src/FubuValidation.Tests/FubuValidation.Tests.csproj
+++ b/src/FubuValidation.Tests/FubuValidation.Tests.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Models\ModelWithNoAttributes.cs" />
     <Compile Include="Models\AddressModel.cs" />
     <Compile Include="Models\SimpleModel.cs" />
+    <Compile Include="Models\SiteModel.cs" />
     <Compile Include="NotificationMessageTester.cs" />
     <Compile Include="NotificationTester.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/FubuValidation.Tests/Models/SiteModel.cs
+++ b/src/FubuValidation.Tests/Models/SiteModel.cs
@@ -1,0 +1,22 @@
+namespace FubuValidation.Tests.Models
+{
+    public class UserModel
+    {
+        [Required]
+        public string Login { get; set; }
+
+        [ContinueValidation]
+        public SiteModel Site { get; set; }
+    }
+
+    public class SiteModel
+    {
+        [Required]
+        public string Name { get; set; }
+
+        [ContinueValidation]
+        public ContactModel Contact { get; set; }
+
+        public ContactModel AlternateContact { get; set; }
+    }
+}


### PR DESCRIPTION
Guarded against an unlikely edge case when finding validation continues in property chain accessors.

Also refactored the continue rule finding code a bit for readability.

Nothing earth shaking. Ignore if you like.
