### PR TITLE
Introduced "label" member for ValidationError class

### DIFF
--- a/src/FubuValidation/Notification.cs
+++ b/src/FubuValidation/Notification.cs
@@ -15,14 +15,16 @@ namespace FubuValidation
         {
         }
 
-        public ValidationError(string field, string message)
+        public ValidationError(string field, string label, string message)
         {
             this.field = field;
             this.message = message;
+            this.label = label;
         }
 
         public string field { get; set; }
         public string message { get; set; }
+        public string label { get; set; }
     }
 
     [Serializable]

--- a/src/FubuValidation/NotificationMessage.cs
+++ b/src/FubuValidation/NotificationMessage.cs
@@ -103,10 +103,10 @@ namespace FubuValidation
             var message = GetMessage();
             if (_accessors.Any())
             {
-                return _accessors.Select(a => new ValidationError(a.Name, message));
+                return _accessors.Select(a => new ValidationError(a.Name, LocalizationManager.GetHeader(a.InnerProperty), message));
             }
 
-            return new ValidationError[]{new ValidationError(string.Empty, message)};
+            return new ValidationError[]{new ValidationError(string.Empty, string.Empty, message)};
         }
     }
 }


### PR DESCRIPTION
Will allow to display localized field names in the client validation messages.

e.g.:
Setup Localization (ES-es):
Required : "Campo requerido"
Name Property : "Nombre"

before:
Client template:
"< li >${x.name} - ${x.message}< /li >"
Output:
"< li >Name - Campo requerido< /li >"

now:
Client template:
"< li >${x.label} - ${x.message}< /li >"
Output:
"< li >Nombre - Campo requerido< /li >"
