### PR TITLE
Update src/FubuMVC.Validation/content/scripts/fubuvalidation.js

### DIFF
--- a/src/FubuMVC.Validation/content/scripts/fubuvalidation.js
+++ b/src/FubuMVC.Validation/content/scripts/fubuvalidation.js
@@ -137,7 +137,7 @@
         toValidationContext: function (continuation) {
             var self = this;
             this.eachError(continuation, function (e) {
-                if (!e.element) {
+                if (!e.element && e.field) {
                     e.element = self.findElement(continuation, e.field, e);
                 }
             });


### PR DESCRIPTION
Constrained the call to findElement by checking that the error field member is not null or empty.
When a error is registered as follows:
https://gist.github.com/3520765
...according to this test:
https://github.com/DarthFubuMVC/fubuvalidation/blob/master/src/FubuValidation.Tests/NotificationTester.cs#L87
...it will serialize the error with a field equals to string.Empty.
When trying to locate the element that targets this error, jquery will throw an exception due to the invalid search expression fubuvalidation attempts to execute:

$("#",context.form) => Error: Syntax error, unrecognized expression: #
