### PR TITLE
Created activateAjaxForms plug in

### DIFF
--- a/src/FubuMVC.Validation/content/scripts/ValidationActivator.js
+++ b/src/FubuMVC.Validation/content/scripts/ValidationActivator.js
@@ -1,11 +1,17 @@
-﻿$(document).ready(function () {
-    $('form.validated-form').each(function () {
-        var mode = $(this).data('validationMode');
-        $(this).validate({
-            ajax: mode == 'ajax',
-            continuationSuccess: function (continuation) {
-                continuation.form.trigger('validation:success', continuation);
-            }
+$(document).ready(function () {
+    $.fn.activateAjaxForms = function () {
+        return this.each(function () {
+            var container = $(this);
+            $('form.validated-form', container).each(function () {
+                var mode = $(this).data('validationMode');
+                $(this).validate({
+                    ajax: mode == 'ajax',
+                    continuationSuccess: function (continuation) {
+                        continuation.form.trigger('validation:success', continuation);
+                    }
+                });
+            });
         });
-    });
+    };
+    $(document).activateAjaxForms();
 });


### PR DESCRIPTION
Useful for scenarios where you get a form from an ajax call and you need to bootstrap the validation hooks.
E.g.: SPA(Single Page Applications) widgets.
