### PR TITLE
Add MimeType.Any to DefaultValidationSummaryWriter

### DIFF
--- a/src/FubuMVC.Validation/UI/DefaultValidationSummaryWriter.cs
+++ b/src/FubuMVC.Validation/UI/DefaultValidationSummaryWriter.cs
@@ -31,7 +31,10 @@ namespace FubuMVC.Validation.UI
 
         public IEnumerable<string> Mimetypes
         {
-            get { yield return MimeType.Html.Value; }
+            get { 
+                yield return MimeType.Html.Value;
+                yield return MimeType.Any.Value; 
+                }
         }
     }
 }


### PR DESCRIPTION
Useful for scenarios where a form is fetch using ajax.
Without this change, the ValidationSummary is written as json instead of html.
E.g.: In FubuMVC.HelloValidation (after fixing runtime issues and removing WithValidationSummary extension method) execute $.get("/create/product") and you will see a "{}" string in the response.
