### PR TITLE
Added ability to create an inline validation rule.

### DIFF
--- a/src/FubuValidation.Tests/ClassValidationRulesTester.cs
+++ b/src/FubuValidation.Tests/ClassValidationRulesTester.cs
@@ -70,6 +70,28 @@ namespace FubuValidation.Tests
         }
 
         [Test]
+        public void register_custom_rule()
+        {
+            theRules.Property(x => x.Name)
+                .Custom(x => x.Age + 1 > 12);
+
+            rulesFor(x => x.Name).Single()
+                .ShouldBeOfType<CustomFieldValidationRule<ClassValidationRulesTarget>>();
+        }
+
+        [Test]
+        public void register_custom_rule_with_token()
+        {
+            var token = StringToken.FromKeyString("Test");
+            theRules.Property(x => x.Name)
+                .Custom(x => x.Age + 1 > 12, token);
+
+            rulesFor(x => x.Name).Single()
+                .ShouldBeOfType<CustomFieldValidationRule<ClassValidationRulesTarget>>()
+                .Token.ShouldEqual(token);
+        }
+
+        [Test]
         public void register_multiple_required_rules()
         {
             theRules.Require(x => x.Name, x => x.Address1);

--- a/src/FubuValidation.Tests/Fields/CustomTester.cs
+++ b/src/FubuValidation.Tests/Fields/CustomTester.cs
@@ -1,0 +1,57 @@
+using System.Linq;
+using FubuTestingSupport;
+using FubuValidation.Fields;
+using FubuValidation.Tests.Models;
+using NUnit.Framework;
+
+namespace FubuValidation.Tests.Fields
+{
+    [TestFixture]
+    public class CustomTester
+    {
+        private SimpleModel theModel;
+        private CustomFieldValidationRule<SimpleModel> theRule;
+
+        [SetUp]
+        public void BeforeEach()
+        {
+            theModel = new SimpleModel();
+            theRule = new CustomFieldValidationRule<SimpleModel>(x => (x.Number + 1) /2 == 7);
+        }
+
+        [Test]
+        public void should_not_register_any_messages()
+        {
+            theModel.Number = 14;
+
+            theRule.ValidateProperty(theModel, x => x.Number)
+                   .MessagesFor<SimpleModel>(x => x.Number)
+                   .Select(x => x.StringToken)
+                   .Any().ShouldBeFalse();
+        }
+
+        [Test]
+        public void should_have_message_when_expression_is_false()
+        {
+            theModel.Number = 12;
+
+            theRule.ValidateProperty(theModel, x => x.Number)
+                   .MessagesFor<SimpleModel>(x => x.Number)
+                   .Select(x => x.StringToken)
+                   .ShouldHaveTheSameElementsAs(ValidationKeys.InvalidFormat);
+        }
+
+        [Test]
+        public void should_have_custom_message()
+        {
+            var customToken = new ValidationKeys("That is some bad math.");
+            theModel.Number = 12;
+            theRule = new CustomFieldValidationRule<SimpleModel>(x => (x.Number + 1) /2 == 7, customToken);
+
+            theRule.ValidateProperty(theModel, x => x.Number)
+                   .MessagesFor<SimpleModel>(x => x.Number)
+                   .Select(x => x.StringToken)
+                   .ShouldHaveTheSameElementsAs(customToken);
+        }
+    }
+}

--- a/src/FubuValidation.Tests/FubuValidation.Tests.csproj
+++ b/src/FubuValidation.Tests/FubuValidation.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="FieldEqualityRuleTester.cs" />
     <Compile Include="Fields\attribute_scanning_tester.cs" />
     <Compile Include="Fields\ConditionalFieldRuleTester.cs" />
+    <Compile Include="Fields\CustomTester.cs" />
     <Compile Include="Fields\EmailFieldRuleTester.cs" />
     <Compile Include="Fields\FieldAccessRuleRegistryTester.cs" />
     <Compile Include="Fields\FieldRulesRegistryTester.cs" />

--- a/src/FubuValidation.Tests/Models/SimpleModel.cs
+++ b/src/FubuValidation.Tests/Models/SimpleModel.cs
@@ -8,5 +8,6 @@
         public int GreaterThanZero { get; set; }
         [MaximumStringLength(10)]
         public int NoMoreThanTen { get; set; }
+        public int Number { get; set; }
     }
 }

--- a/src/FubuValidation/ClassValidationRules.cs
+++ b/src/FubuValidation/ClassValidationRules.cs
@@ -148,6 +148,16 @@ namespace FubuValidation
                 If<IsValid>();
             }
 
+            public FieldValidationExpression Custom(Func<T, bool> condition)
+            {
+                return register(new CustomFieldValidationRule<T>(condition));
+            }
+
+            public FieldValidationExpression Custom(Func<T, bool> condition, StringToken token)
+            {
+                return register(new CustomFieldValidationRule<T>(condition, token));
+            }
+
             public FieldValidationExpression MaximumLength(int length)
             {
                 return register(new MaximumLengthRule(length));

--- a/src/FubuValidation/Fields/CustomFieldValidationRule.cs
+++ b/src/FubuValidation/Fields/CustomFieldValidationRule.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using FubuCore.Reflection;
+using FubuLocalization;
+
+namespace FubuValidation.Fields
+{
+    public class CustomFieldValidationRule<T> : IFieldValidationRule
+    {
+        private readonly Func<T, bool> theCondition;
+
+        public CustomFieldValidationRule(Func<T, bool> condition)
+        {
+            theCondition = condition;
+            Token = ValidationKeys.InvalidFormat;
+        }
+
+        public CustomFieldValidationRule(Func<T, bool> condition, StringToken token)
+        {
+            theCondition = condition;
+            Token = token ?? ValidationKeys.InvalidFormat;
+        }
+
+        public void Validate(Accessor accessor, ValidationContext context)
+        {
+            if (theCondition((T)context.Target)) return;
+
+            context.Notification.RegisterMessage(accessor, Token, new TemplateValue[0]);
+        }
+
+        public StringToken Token { get; set; }
+        public ValidationMode Mode { get; set; }
+    }
+}

--- a/src/FubuValidation/FubuValidation.csproj
+++ b/src/FubuValidation/FubuValidation.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Fields\ClassFieldValidationRules.cs" />
     <Compile Include="Fields\CollectionLengthRule.cs" />
     <Compile Include="Fields\ContinuationFieldRule.cs" />
+    <Compile Include="Fields\CustomFieldValidationRule.cs" />
     <Compile Include="Fields\EmailFieldRule.cs" />
     <Compile Include="Fields\FieldRuleSource.cs" />
     <Compile Include="Fields\FieldRulesRegistry.cs" />


### PR DESCRIPTION
Not sure if there is anything like this but I didn't see anything. Sometimes there are really weird rules that need one off scenarios, instead of making an IFieldValidationRule, it would be nice to just inline it:

```
Property(x => x.FirstDate)
            .Custom(x => 
             {
                   var lastDate = x.ThirdDate.AddDays(1);
                   return x.FirstDate > x.SecondDate > x.ThirdDate;
             }, StringToken.FromKeyString("First day must be greater then second and at"
                + "least a day after the third."));
```
